### PR TITLE
Add numpy mod

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -109,17 +109,17 @@ profiles {
       clusterOptions = "-l centos=7"
 
       withName: generate_sheets {
-        module = 'modules:modules-init:modules-gs:python/3.7.7'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7'
         memory = '1 GB'
       }
 
       withName: check_sample_sheet {
-        module = 'modules:modules-init:modules-gs:python/3.7.7'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7'
         memory = '1 GB'
       }
 
       withName: make_sample_sheet {
-        module = 'modules:modules-init:modules-gs:python/3.7.7'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7'
         memory = '1 GB'
       }
 
@@ -129,7 +129,7 @@ profiles {
       }
 
       withName: seg_sample_fastqs1 {
-        module = 'modules:modules-init:modules-gs:python/3.7.7:zlib/1.2.11:pigz/2.3'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7:zlib/1.2.11:pigz/2.3'
         cpus = 8
         memory = '1 GB'
         penv = 'serial'
@@ -141,22 +141,22 @@ profiles {
       }
 
       withName: seg_sample_fastqs2 {
-        module = 'modules:modules-init:modules-gs:python/3.7.7:zlib/1.2.11:pigz/2.3'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7:zlib/1.2.11:pigz/2.3'
         penv = 'serial'
         cpus = 8
         memory = '1 GB'
       }
 
       withName: recombine_fastqs {
-        module = 'modules:modules-init:modules-gs:python/3.7.7'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7'
       }
 
       withName: recombine_csvs {
-        module = 'modules:modules-init:modules-gs:python/3.7.7'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7'
       }
 
       withName: recombine_jsons {
-        module = 'modules:modules-init:modules-gs:python/3.7.7'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7'
       }
 
       withName: demux_dash {
@@ -165,12 +165,12 @@ profiles {
       }
 
       withName: run_recovery {
-        module = 'modules:modules-init:modules-gs:python/3.7.7'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7'
         memory = '4 GB'
       }
 
       withName: sum_recovery {
-        module = 'modules:modules-init:modules-gs:python/3.7.7'
+        module = 'modules:modules-init:modules-gs:numpy/1.21.1:python/3.7.7'
         memory = '4 GB'
       }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,6 @@
 //includeConfig 'experiment.config'
 
-manifest.version = '2.2.6'
+manifest.version = '2.2.7'
 
 /*
 ** bbi-dmux process profiles.


### PR DESCRIPTION
The rogue numpy used by the pipeline has been removed by GSIT. numpy/1.21.1 module is now required to be loaded to run the pipeline.